### PR TITLE
fix handling of CODE refs stored in stash

### DIFF
--- a/lib/Role/Basic.pm
+++ b/lib/Role/Basic.pm
@@ -351,13 +351,12 @@ sub _get_methods {
     my $stash = do { no strict 'refs'; \%{"${target}::"} };
 
     my %methods;
-    foreach my $item ( values %$stash ) {
+    foreach my $name ( keys %$stash ) {
+        my $item = $stash->{$name};
 
         next unless my $code = _get_valid_method( $target, $item );
 
         # this prevents a "modification of read-only value" error.
-        my $name = $item;
-        $name =~ s/^\*$target\:://;
         my $source = _sub_package($code);
         $methods{$name} = {
             code   => $code,
@@ -369,8 +368,10 @@ sub _get_methods {
 
 sub _get_valid_method {
     my ( $target, $item ) = @_;
-    return if ref $item;
-    my $code = *$item{CODE} or return;
+    my $code = ref $item eq 'CODE' ? $item
+             : ref \$item eq 'GLOB' ? *$item{CODE}
+             : undef;
+    return if !defined $code;
 
     my $source = _sub_package($code) or return;
 


### PR DESCRIPTION
Perl has an optimization allowing code refs to be stored directly in the stash, without an associated GLOB. For all stable perl releases, this will only happen for the 'main' namespace. Some development releases (and possibly future stable) releases will do this for all packages.

Account for code refs stored directly in the stash when trying to list all of the methods for a package.